### PR TITLE
Fix for perl 5.18

### DIFF
--- a/lib/uni/perl/dumper.pm
+++ b/lib/uni/perl/dumper.pm
@@ -30,7 +30,7 @@ sub dumper_dd (@) {
 			->Useqq(1)
 			->Quotekeys(0)
 			->Dump;
-		$s =~ s{\\x\{([a-f0-9]{1,4})\}}{chr hex $1}sge;
+		$s =~ s/\\x\{([a-f0-9]{1,4})\}/chr hex $1/sge;
 		$s;
 	};
 	goto &{ caller().'::dumper' };

--- a/t/06-dumper.t
+++ b/t/06-dumper.t
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+
+use Test::More tests => 1
+	+do { eval { require Test::NoWarnings;Test::NoWarnings->import; 1 } || 0 };
+
+use uni::perl ':dumper';
+is(dumper({ тест => 'Проверка' }), qq|{\n  "тест" => "Проверка"\n}\n|, 'dumper converts utf-8');


### PR DESCRIPTION
Useless use of '\'; doesn't escape metacharacter '{' at dumper.pm line 33
